### PR TITLE
Blog view fixes & improvements

### DIFF
--- a/assets/scss/templates/_main.scss
+++ b/assets/scss/templates/_main.scss
@@ -50,8 +50,8 @@
 
 // blog card
 .card-img {
-  object-fit: cover; 
-  width: 100%; 
+  object-fit: cover;
+  width: 100%;
   height: 10vw;
 }
 

--- a/assets/scss/templates/_main.scss
+++ b/assets/scss/templates/_main.scss
@@ -48,6 +48,13 @@
   }
 }
 
+// blog card
+.card-img {
+  object-fit: cover; 
+  width: 100%; 
+  height: 10vw;
+}
+
 // blog post
 a.post-title {
   color: $text-color-dark;

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -8,6 +8,9 @@ image = "images/logo.png" # this image will be used as fallback if a page has no
 # contact form action
 contact_form_action = "#" # contact form works with https://formspree.io
 
+# Type of pages to be rendered with a blog view
+blogCategoryType = "category"
+
 # Preloader
 [preloader]
 enable = false

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -22,7 +22,7 @@
         </div>
       </div>
       {{ end }}
-      {{ $paginator := .Paginate .Data.Pages }}
+      {{ $paginator := .Paginate  (where .Data.Pages "Type" "!=" "featured") }}
       {{ range $paginator.Pages }}
       <div class="col-lg-4 col-sm-6 mb-5">
         <div class="card border-0">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,7 +3,7 @@
 {{ partial "page-header.html" . }}
 
 <!-- checking blog -->
-{{ if or (or (eq .Section "post") (eq .Section "blog")) (or (eq .Section "categories") (eq .Section "tags") )}}
+{{ if or (or (eq .Section "post") (eq .Section "blog") (eq .Type site.Params.blogCategoryType)) (or (eq .Section "categories") (eq .Section "tags") )}}
 
 <section class="section">
   <div class="container">


### PR DESCRIPTION
- Align all card images of a blog page by configuring the same height for all card images in a row
- Make blog page style usable for custom page type (other sections than "post", "blog", "categories", or "tags")
- Avoid duplicates cards between featured and non featured parts of a blog page