### PR TITLE
SEO: Added missing meta description

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,6 +13,7 @@
 {{ end }}
 <link rel="alternate" hreflang="x-default" href="{{ .RelPermalink | absLangURL }}">
 {{ end }}
+<meta name="description" content="{{ if .Params.description }}{{ .Params.description }}{{ else if .Site.Params.Description }}{{ .Site.Params.Description }}{{ end }}" />
 {{ with site.Params.author }}
 <meta name="author" content="{{ . }}">{{ end }}
 {{ hugo.Generator }}


### PR DESCRIPTION
Meta description is vital for SEO and read by search engines bots such as googlebot . The `og:description` tag is used by social media bots. Both need to be configured in an optimized page head

Reference : 
 - https://developers.google.com/search/docs/advanced/crawling/special-tags
 - https://www.clairecodes.com/blog/2019-05-03-meta-descriptions-in-hugo-templates/